### PR TITLE
support for passing a hash instead of an array as first argument to Pagerank constructor

### DIFF
--- a/lib/pagerank.js
+++ b/lib/pagerank.js
@@ -34,7 +34,7 @@ function Pagerank (nodeMatrix, linkProb, tolerance, callback, debug) {
     this.callback = callback
 
     //Number of outgoing nodes
-    this.pageCount = this.outgoingNodes.length
+    this.pageCount = Object.keys(this.outgoingNodes).length 
     //**Coeff:** coefficient for the likelihood that a page will be visited.
     this.coeff = (1-linkProb)/this.pageCount
     
@@ -84,6 +84,7 @@ Pagerank.prototype.reportDebug = function (count) {
 Pagerank.prototype.iterate = function (count) {
 
     var result = []
+    var resultHash={};
 
     //For each node, we look at the incoming edges and 
     //the weight of the node connected via each edge. 
@@ -111,8 +112,16 @@ Pagerank.prototype.iterate = function (count) {
     }
 
     //When we have all results (no weights are changing) we return via callback
-    if (result.length == this.pageCount) 
+    if (result.length == this.pageCount) {
+        if( this.outgoingNodes instanceof Object && !(this.outgoingNodes instanceof Array)) {
+            //turn the result array into a hash
+            for( i in this.outgoingNodes ) {
+                resultHash[i]=result[Object.keys(this.outgoingNodes).indexOf(i)];
+            }
+            return this.callback(null, resultHash);
+        }
         return this.callback(null, result)
+    }
     
     //if debug is set, print each iteration
     if (this.debug) this.reportDebug(count) 

--- a/test/pagerank.js
+++ b/test/pagerank.js
@@ -18,8 +18,17 @@ describe('Page rank', function () {
     var nodeMatrix = [
         [1],[0,2],[0,3,4],[4,5],[2,6],[0,6],[3]
     ]
+    var nodeHash={
+        "0":["1"],
+        "1":["0","2"],
+        "2":["0","3","4"],
+        "3":["4","5"],
+        "4":["2","6"],
+        "5":["0","6"],
+        "6":["3"]
+    }
             
-    expectedResponse = [ 
+    var expectedResponse = [ 
         0.1751523680914745,
         0.17030808430632474,
         0.1505779562978131,
@@ -29,6 +38,16 @@ describe('Page rank', function () {
         0.11680129518391424
     ]
 
+    var expectedHashResponse={
+        "0":0.1751523680914745,
+        "1":0.17030808430632474,
+        "2":0.1505779562978131,
+        "3":0.1633947196406794,
+        "4":0.13353508156024055,
+        "5":0.09087132727586017,
+        "6":0.11680129518391424
+    }
+
     it('correctly ranks nodes', function (done) {
 
         Pagerank(nodeMatrix, linkProb, tolerance, function (err, res) {
@@ -37,6 +56,20 @@ describe('Page rank', function () {
             should.exist(res)
             res.should.be.instanceof(Array).and.have.lengthOf(7)
             res.should.eql(expectedResponse)
+        })
+    
+        done()
+    })
+
+    it('correctly ranks nodes (hash)', function (done) {
+
+        Pagerank(nodeHash, linkProb, tolerance, function (err, res) {
+
+            should.not.exist(err)
+            should.exist(res)
+            res.should.be.instanceof(Object).and.not.instanceof(Array)
+            Object.keys(res).should.have.lengthOf(7)
+            res.should.eql(expectedHashResponse)
         })
     
         done()


### PR DESCRIPTION
I wanted to pass a hash (associative array) instead of an array. I modified the result object to also be a hash. I added tests too
