### PR TITLE
fixed main to point at ./lib/pagerank instead of ./lib/kmeans

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "should":"latest"
     }
     , "engines": { "node": "latest" }
-    , "main": "./lib/kmeans"
+    , "main": "./lib/pagerank"
     , "repository": {
         "type": "git"
         , "url": "http://github.com/stevemacn/pagerank.git"

--- a/test/package.js
+++ b/test/package.js
@@ -1,0 +1,37 @@
+var should = require('should')
+  , fs = require('fs')
+  , path = require('path');
+
+describe('PageRank', function () {
+
+    //Larger numbers (0.85) provide low chance of random links 
+    linkProb = 0.85 
+    
+    //accuracy at which we terminate 
+    tolerance = 0.0001 
+    
+    var nodeMatrix = [
+        [1],[0,2],[0,3,4],[4,5],[2,6],[0,6],[3]
+    ];
+            
+    expectedResponse = [ 
+        0.1751523680914745,
+        0.17030808430632474,
+        0.1505779562978131,
+        0.1633947196406794,
+        0.13353508156024055,
+        0.09087132727586017,
+        0.11680129518391424
+    ];
+
+    it('should load package by requiring the package directory', function (done) {
+        var Pagerank = require('..');
+
+        Pagerank(nodeMatrix, linkProb, tolerance, function (err, res) {
+            should.not.exist(err);
+            res.should.eql(expectedResponse);
+        });
+    
+        done();
+    });
+});


### PR DESCRIPTION
with main:'./lib/kmeans' I'm unable to include pagerank in a project because the actual entry point is lib/pagerank, this fixes it

test:
Wencelaus:PageRank aumkara$ npm test

> pagerank@0.0.1 test /Users/aumkara/workspace/PageRank
> mocha -t 30000 -R spec

  Page rank
    ✓ correctly ranks nodes

  1 passing (23ms)
