### PR TITLE
fixed bug4: the wrong comparison operators are used when checking within tolerance

### DIFF
--- a/lib/pagerank.js
+++ b/lib/pagerank.js
@@ -104,7 +104,9 @@ Pagerank.prototype.iterate = function (count) {
             , min = this.probabilityNodes[b]-this.tolerance    
 
         //if the result has changed push that result
-        if (min <= res >= max) result.push(res)
+        if (min <= res && res<= max) {
+            result.push(res);
+        }
     
         //update the probability for node *b*
         this.probabilityNodes[b]=res


### PR DESCRIPTION
the wrong comparison operators are used to check if result is within tolerance.
I updated the style of this section to make it a little easier to read (added braces, a newline and a semicolon) and changed the comparison to

```
min <= res <= max )
```

tests still pass

```
Wencelaus:PageRank aumkara$ npm test

> pagerank-js@0.0.1 test /Users/aumkara/workspace/PageRank
> mocha -t 30000 -R spec



  PageRank
    ✓ should load package by requiring the package directory

  Page rank
    ✓ correctly ranks nodes


  2 passing (27ms)
```
